### PR TITLE
Include pcre package to fix wget dyld not founding libpcre

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,5 +6,5 @@
 class wget {
   include homebrew
 
-  package { 'wget': }
+  package { ['pcre', 'wget' ]: }
 }


### PR DESCRIPTION
tombar@Erebor ~> wget google.com
dyld: Library not loaded: /opt/boxen/homebrew/lib/libpcre.1.dylib
  Referenced from: /opt/boxen/homebrew/bin/wget
  Reason: image not found
fish: Job 1, 'wget google.com' terminated by signal SIGTRAP (Trace or breakpoint trap)
